### PR TITLE
change code climate to codacy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,15 +14,27 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - uses: gradle/gradle-build-action@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: 8.7
-      - run: ./gradlew checkstyleMain
-      - run: ./gradlew test
+          fetch-depth: 0
+      - name: Execute Gradle build
+        run: ./gradlew build
       - name: Generate coverage report
         run: make report
-      # - name: Publsish coverage report to codacy
-      #   uses: codacy/codacy-coverage-reporter-action@v1.3.0
+      # - name: Cache SonarQube packages
+      #   uses: actions/cache@v4
       #   with:
-      #     project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-      #     coverage-reports: build/reports/jacoco/test/jacocoTestReport.xml
+      #     path: ~/.sonar/cache
+      #     key: ${{ runner.os }}-sonar
+      #     restore-keys: ${{ runner.os }}-sonar
+      # - name: Cache Gradle packages
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: ~/.gradle/caches
+      #     key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+      #     restore-keys: ${{ runner.os }}-gradle
+      # - name: Build and analyze
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      #   run: ./gradlew sonar --info

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
     id("io.freefair.lombok") version "8.6"
     id("com.github.ben-manes.versions") version "0.50.0"
     id("com.github.johnrengelman.shadow") version "8.1.1"
+    // Плагин для публикации отчета о покрытии тестами на SonarQube
+    id("org.sonarqube") version "6.0.1.5171"
 }
 
 group = "io.hexlet"
@@ -38,3 +40,12 @@ tasks.test {
 }
 
 tasks.jacocoTestReport { reports { xml.required.set(true) } }
+
+// Конфигурация плагина org.sonarqube
+sonar {
+    properties {
+        property("sonar.projectKey", "hexlet_java-package")
+        property("sonar.organization", "hexlet")
+        property("sonar.host.url", "https://sonarcloud.io")
+    }
+}


### PR DESCRIPTION
Заменил Code Climate на Codecy, так как Code Climate больше не дает добавлять новые репозитории в свой аккаунт, а их новый проект по качеству qlty пока сырой